### PR TITLE
Fix bug with deprecated plugin "react-tap-event-plugin"

### DIFF
--- a/resources/assets/js/components/QuestionForm.js
+++ b/resources/assets/js/components/QuestionForm.js
@@ -1,41 +1,39 @@
-import React from 'react';
+import React, {Component} from 'react';
 import AppActions from '../actions/AppActions';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import RaisedButton from 'material-ui/RaisedButton';
-import injectTapEventPlugin from 'react-tap-event-plugin';
-injectTapEventPlugin();
+//import injectTapEventPlugin from 'react-tap-event-plugin';
+//injectTapEventPlugin();
 
-function getAppState(){
-	return {
+
+
+
+class QuestionForm extends Component{
+
+	state = {
 		titleText : 'You can ask question',
 		thankYouText : 'Thank You for your message!',
 		buttonText : 'Send',
 		text: ""
-	};
-}
+	}
 
-var QuestionForm = React.createClass({
-
-	getInitialState: function(){
-		return getAppState();
-	},
-
-	handleTextChange: function (event) {
+	handleTextChange(event) {
 		this.setState( {text: event.target.value});
-	},
+	}
 
-	handleAddQuestion: function () {
+	handleAddQuestion () {
 		var newQuestion = {
 			id: Date.now(),
 			text: this.state.text
-		};
-
+		}
+		
+	
 		AppActions.addItem(newQuestion);
 
 		this.setState({text: '' });
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<div className="panel panel-success">
 				<div className="panel-heading">
@@ -47,18 +45,18 @@ var QuestionForm = React.createClass({
 						<div className="form-group">
 							<input type="text"
 								   value={this.state.text}
-								   onChange={this.handleTextChange}
+								   onChange={this.handleTextChange.bind(this)}
 								   className="form-control"
 								   placeholder="Enter question" />
 						</div>
 						<MuiThemeProvider>
-							<RaisedButton label={this.state.buttonText} onClick={this.handleAddQuestion} />
+							<RaisedButton label={this.state.buttonText} onClick={this.handleAddQuestion.bind(this)} />
 						</MuiThemeProvider>
 					</form>
 				</div>
 			</div>
 		);
 	}
-});
+};
 
 export default QuestionForm;


### PR DESCRIPTION
React 16.4 removes a lot of internals (#121) plugin "react-tap-event-plugin" depends on and will break the plugin. Since the problem it solves has been fixed in most browsers by now you should migrate away from this plugin.