### PR TITLE
Replacement "createClass" for abilitty to run on React 16+.

### DIFF
--- a/resources/assets/js/components/OnOffModule.js
+++ b/resources/assets/js/components/OnOffModule.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Component} from 'react';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import Toggle from 'material-ui/Toggle';
 
@@ -10,15 +10,13 @@ const styles = {
         marginBottom: 16,
     }
 };
-var OnOffModule = React.createClass({
+class OnOffModule extends Component{
 
-    getInitialState: function() {
-        return {
+   state =  {
             stateBtn: true
-        };
-    },
+    }
 
-    render: function() {
+    render () {
         return (
             <MuiThemeProvider>
                 <Toggle
@@ -30,6 +28,6 @@ var OnOffModule = React.createClass({
             </MuiThemeProvider>
         );
     }
-});
+};
 
 export default OnOffModule;


### PR DESCRIPTION
Fix bug "In React 16 createClass have already removed entirely. 
Uncaught TypeError: react__WEBPACK_IMPORTED_MODULE_0___default.a.createClass is not a function"