### PR TITLE
Fix bug with loss of context for Emitter

### DIFF
--- a/resources/assets/js/stores/OnOffStore.js
+++ b/resources/assets/js/stores/OnOffStore.js
@@ -1,9 +1,10 @@
 import AppConstants from '../constants/AppConstants';
 import AppDispatcher from '../dispatcher/AppDispatcher';
 import assign from 'object-assign';
-import AppAPI from '../utils/AppAPI.js';
+import AppAPI from '../utils/appAPI.js';
 var EventEmitter = require('events').EventEmitter;
 
+var eventEmitter = new EventEmitter();
 var _stateBtn = true;
 
 var OnOffStore = assign({}, EventEmitter.prototype, {
@@ -13,14 +14,14 @@ var OnOffStore = assign({}, EventEmitter.prototype, {
 	},
 
 	emitChange: function () {
-		this.emit(AppConstants.CHANGE_ON_OFF);
+		eventEmitter.emit(AppConstants.CHANGE_ON_OFF);
 	},
 
 	addChangeListener: function (callback) {
-		this.on(AppConstants.CHANGE_ON_OFF, callback);
+		eventEmitter.on(AppConstants.CHANGE_ON_OFF, callback);
 	},
 	removeChangeListener: function (callback) {
-		this.removeListener(AppConstants.CHANGE_ON_OFF, callback);
+		eventEmitter.removeListener(AppConstants.CHANGE_ON_OFF, callback);
 	}
 });
 


### PR DESCRIPTION
Fix bug with loss of context for Emitter on React 15.9+
and little bug "does not match the corresponding name: '.\src\utils\appAPI.js'"